### PR TITLE
Updates to UFO metadata management

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -146,7 +146,20 @@ Default normalization behaviours include:
 
 Most of the above can be overridden by [parameters](#parameters)
 
-The check & fix tests are being developed, and will cover items like required fields in fontinfo.plist.  The check & fix behaviour can be controlled by [parameters](#parameters), including turning off by setting the checkfix parameter to none.
+The check & fix tests are based on [Font Development Best Practices](https://silnrsi.github.io/FDBP/en-US/index.html) and include:
+- fontinfo.plist
+ - Required fields
+ - Fields to be deleted
+ - Fields to constructed from other fields
+ - Specific recomended values for some fields
+- lib.plist
+ - Required fields
+ - Recomended values
+ - Fields that should not be present
+
+With some fields errors are fixed automatically and for others warnings are issued.
+
+The check & fix behaviour can be controlled by [parameters](#parameters), currently just the checkfix parameter which cane be set to 'check' for check but don't fix or none for no checking.
 
 ## Known limitations
 The following are known limitations that will be addressed in the future:

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -224,7 +224,7 @@ Example that expands the stokes in a UFO font `SevdaStrokeMaster-Regular.ufo` by
 psfexpandstroke SevdaStrokeMaster-Regular.ufo Sevda-Regular.ufo 13
 ```
 
-Note that this only expands the outlines - it does not remove any resulting overlap. 
+Note that this only expands the outlines - it does not remove any resulting overlap.
 
 
 ---
@@ -290,6 +290,8 @@ Usage: **`psfglyphs2ufo fontfile.glyphs masterdir`**
 _([Standard options](docs.md#standard-command-line-options) also apply)_
 
 Exports one UFO file per master found in the fontfile.glyphs file, and places it in the directory specified as masterdir.
+
+In a round-trip ufo -> glyphs -> ufo there is currently there is some data loss in the standard glyphs -> ufo conversion, so the script restores some fields from the original ufos if they are present in the masterdir.
 
 Example usage:
 

--- a/lib/silfont/core.py
+++ b/lib/silfont/core.py
@@ -388,7 +388,10 @@ def execute(tool, fn, argspec, chain = None):
             if logname == "":
                 logfile = None
             else:
-                if not quiet: logger.log('Opening log file for output: '+logname, "P")
+                (logname, logpath, exists) = fullpath(logname)
+                if not exists:
+                    logger.log("Log file directory " + logpath + " does not exist", "S")
+                if not quiet: logger.log('Opening log file for output: ' + logname, "P")
                 try:
                     logfile = open(logname, "w")
                 except Exception as e:
@@ -465,7 +468,10 @@ def execute(tool, fn, argspec, chain = None):
             if not quiet: logger.log('Opening file for input: '+aval, "P")
             aval = csvreader(aval)
         elif atype == 'outfile':
-            if not quiet: logger.log('Opening file for output: '+aval, "P")
+            (aval, path, exists) = fullpath(aval)
+            if not exists:
+                logger.log("Output file directory " + path + " does not exist", "S")
+            if not quiet: logger.log('Opening file for output: ' + aval, "P")
             try:
                 aval = codecs.open(aval, 'w', 'utf-8')
             except Exception as e:
@@ -594,3 +600,8 @@ def str2bool(v):  # If v is not a boolean, convert from string to boolean
     else:
         v = None
     return v
+
+def fullpath(filen): # Changes file name to one with full path and checks directory exists
+    fullname = os.path.abspath(filen)
+    (fpath,dummy) = os.path.split(fullname)
+    return fullname, fpath, os.path.isdir(fpath)

--- a/lib/silfont/scripts/psfglyphs2ufo.py
+++ b/lib/silfont/scripts/psfglyphs2ufo.py
@@ -80,43 +80,54 @@ def doit(args):
                 del ufo.lib["UFO.lib"]
                 logger.log("UFO.lib field deleted", "I")
 
-            # Restore values from backups - currently from fontname-bk.ufo in same folder as input .gylphs file
-            bklibplist = silfont.ufo.Uplist(font=None, dirn=os.path.join(glyphsdir,fontname+"-bk.ufo"),
-                                            filen="lib.plist")
+            # Restore values from original UFOs, assuming nameed as <fontname>.ufo in same directory as input .gylphs file
 
-            for key in librestorekeys:
-                if key in bklibplist:
-                    new = bklibplist.getval(key)
-                    current = None if key not in ufo.lib else ufo.lib[key]
-                    if current == new:
-                        continue
-                    else:
-                        ufo.lib[key] = new
-                        logchange(logger, " restored from backup ufo. ", key, current, new)
+            ufodir = os.path.join(glyphsdir,fontname+".ufo")
+            try:
+                origlibplist = silfont.ufo.Uplist(font=None, dirn=ufodir, filen="lib.plist")
+            except Exception as e:
+                logger.log("Unable to open lib.plist in " + ufodir + "; values will not be restored", "E")
+                origlibplist = None
 
-            for key in libdeletekeys:
-                if key in ufo.lib:
-                    current = ufo.lib[key]
-                    del ufo.lib[key]
-                    logchange(logger, " deleted. ", key, current, None)
+            if origlibplist is not None:
+                for key in librestorekeys:
+                    if key in origlibplist:
+                        new = origlibplist.getval(key)
+                        current = None if key not in ufo.lib else ufo.lib[key]
+                        if current == new:
+                            continue
+                        else:
+                            ufo.lib[key] = new
+                            logchange(logger, " restored from backup ufo. ", key, current, new)
+
+                for key in libdeletekeys:
+                    if key in ufo.lib:
+                        current = ufo.lib[key]
+                        del ufo.lib[key]
+                        logchange(logger, " deleted. ", key, current, None)
 
             # fontinfo.plist processing
 
             logger.log("Checking fontinfo.plist", "P")
 
             fontinfo = ufo.info
-            bkfontinfo = silfont.ufo.Uplist(font=None, dirn=os.path.join(glyphsdir, fontname + "-bk.ufo"),
-                                            filen="fontinfo.plist")
-            for key in inforestorekeys:
-                if key in bkfontinfo:
-                    new = bkfontinfo.getval(key)
-                    if key in integerkeys: new = int(new)
-                    current = None if not hasattr(ufo.info, key) else  getattr(ufo.info, key)
-                    if current == new:
-                        continue
-                    else:
-                        setattr(ufo.info, key, new)
-                        logchange(logger, " restored from backup ufo. ", key, current, new)
+            try:
+                origfontinfo = silfont.ufo.Uplist(font=None, dirn=ufodir, filen="fontinfo.plist")
+            except Exception as e:
+                logger.log("Unable to open fontinfo.plist in " + ufodir + "; values will not be restored", "E")
+                origfontinfo = None
+
+            if origfontinfo is not None:
+                for key in inforestorekeys:
+                    if key in origfontinfo:
+                        new = origfontinfo.getval(key)
+                        if key in integerkeys: new = int(new)
+                        current = None if not hasattr(ufo.info, key) else  getattr(ufo.info, key)
+                        if current == new:
+                            continue
+                        else:
+                            setattr(ufo.info, key, new)
+                            logchange(logger, " restored from backup ufo. ", key, current, new)
 
         # Write ufo out
         logger.log("Writing out " + fontname, "P")
@@ -140,10 +151,6 @@ def logchange(logger, logmess, key, old, new):
     if len(str(new)) > 21 :
         logger.log("Full new value: " + str(new), "V")
     logger.log("Types: Old - " + str(type(old)) + ", New - " + str(type(new)), "V")
-
-
-
-
 
 
 def cmd(): execute(None, doit, argspec)

--- a/lib/silfont/scripts/psfnormalize.py
+++ b/lib/silfont/scripts/psfnormalize.py
@@ -11,7 +11,7 @@ from silfont.core import execute
 argspec = [
     ('ifont',{'help': 'Input font file'}, {'type': 'infont'}),
     ('ofont',{'help': 'Output font file','nargs': '?' }, {'type': 'outfont'}),
-    ('-l','--log',{'help': 'Log file'}, {'type': 'outfile', 'def': '_conv.log'}),
+    ('-l','--log',{'help': 'Log file'}, {'type': 'outfile', 'def': '_normalize.log'}),
     ('-v','--version',{'help': 'UFO version to convert to'},{})]
 
 def doit(args) :


### PR DESCRIPTION
UFO.py now, by default, runs various check & fix routines on fontinfo.plist and lib.plis
This will apply to most standard UFO scripts.

psfglyphs2ufo now restores data from the original UFO files rather than needing backup copies.