### PR TITLE
Update Builder subclass to stash new debug information

### DIFF
--- a/lib/silfont/scripts/psfbuildfea.py
+++ b/lib/silfont/scripts/psfbuildfea.py
@@ -10,6 +10,7 @@ from fontTools.feaLib.builder import Builder
 from fontTools import configLogger
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.otTables import lookupTypes
+from fontTools.feaLib.lookupDebugInfo import LookupDebugInfo
 
 from silfont.core import execute
 
@@ -40,6 +41,11 @@ class MyBuilder(Builder):
                     latelookups.append(bldr)
             else:
                 bldr.lookup_index = len(lookups)
+                self.lookup_locations[tag][str(bldr.lookup_index)] = LookupDebugInfo(
+                    location=str(bldr.location),
+                    name=self.get_lookup_name_(bldr),
+                    feature=None,
+                )
                 lookups.append(bldr)
                 bldr.map_index = bldr.lookup_index
         numl = len(lookups)


### PR DESCRIPTION
Makes psfbuildfea work again with latest fonttools. See fonttools/fonttools#2065