### PR TITLE
Allow to toggle off updating of `openTypeHeadCreated` when other changes occur

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -82,6 +82,7 @@ Currently only font output parameters can be changed via lib.plist
 | plistIndentFirst | Empty string | Different initial indent for plists | (dict is commonly not indented) |
 | sortDicts | True | sort all plist dicts |  |
 | precision | 6 | decimal precision |  |
+| updateTimestamps | True | Update font timestamps if other changes occur | Controls handling of the `openTypeHeadCreated` field in UFO fontinfo. |
 | renameGlifs | True | Name glifs with standard algorithm |  |
 | UFOversion | (existing) |  | Defaults to the version of the UFO when opened |
 | format1Glifs | False| Force output of format 1 glifs | Includes UFO2-style anchors; for use with FontForge |

--- a/src/silfont/core.py
+++ b/src/silfont/core.py
@@ -87,6 +87,7 @@ class parameters(object):
             ("indentML",         False),  # Should multi-line string values be indented?
             ("plistIndentFirst", ""),     # First indent amount for plists
             ('precision', 6),             # Decimal precision to use in XML output - both for real values and for attributes if float
+            ("updateTimestamps", True),   # Update the value of openTypeHeadCreated field in fontinfo.plist if other changes occur
             ("floatAttribs", ['xScale', 'xyScale', 'yxScale', 'yScale', 'angle']),  # Used with precision above
             ("intAttribs", ['pos', 'width', 'height', 'xOffset', 'yOffset', 'x', 'y']),
             ("sortDicts",        True),   # Should dict elements be sorted alphabetically?
@@ -117,6 +118,7 @@ class parameters(object):
             "plistIndentFirst": "First indent amount for plists",
             "sortDicts": "Should dict elements be sorted alphabetically?",
             "precision": "Decimal precision to use in XML output - both for real values and for attributes if numeric",
+            "updateTimestamps": "Should font timestamps be updated if other changes occur",
             "renameGlifs": "Rename glifs based on UFO3 suggested algorithm",
             "UFOversion": "UFOversion to output - defaults to version of the input UFO",
             "format1Glifs": "Force output format 1 glifs including UFO2-style anchors (was used with FontForge; no longer needed)",

--- a/src/silfont/scripts/psfmakewoffmetadata.py
+++ b/src/silfont/scripts/psfmakewoffmetadata.py
@@ -124,7 +124,9 @@ def doit(args):
             xmlstring += '</array></dict>'
             fi.setelem("woffMetadataCredits", ET.fromstring(xmlstring))
 
-            fi.setval("openTypeHeadCreated", "string", datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"))
+            if font.outparams["updateTimestamps"]:
+                fi.setval("openTypeHeadCreated", "string", datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"))
+
             logger.log("Writing updated fontinfo.plist with values from FONTLOG.txt", "P")
             exists = True if os.path.isfile(os.path.join(font.ufodir, "fontinfo.plist")) else False
             UFO.writeXMLobject(fi, font.outparams, font.ufodir, "fontinfo.plist", exists, fobject=True)

--- a/src/silfont/scripts/psfsyncmasters.py
+++ b/src/silfont/scripts/psfsyncmasters.py
@@ -122,7 +122,8 @@ def doit(args) :
         fipval[field] = pval
     if reqmissing: logger.log("Required fontinfo fields missing from " + psource.source.filename, "S")
     if changes:
-        psource.fontinfo.setval("openTypeHeadCreated", "string",
+        if psource.outparams["updateTimestamps"]:
+            psource.fontinfo.setval("openTypeHeadCreated", "string",
                              datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"))
         psource.write("fontinfo")
 
@@ -200,7 +201,8 @@ def doit(args) :
             dsource.write("lib")
             fchanges = True # Force fontinfo to update so openTypeHeadCreated is set
         if fchanges:
-            dsource.fontinfo.setval("openTypeHeadCreated", "string",
+            if dsource.outparams["updateTimestamps"]:
+                dsource.fontinfo.setval("openTypeHeadCreated", "string",
                                     datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"))
             dsource.write("fontinfo")
 

--- a/src/silfont/ufo.py
+++ b/src/silfont/ufo.py
@@ -679,7 +679,7 @@ class Ufont(object):
         self.logger.log("Writing font to " + outdir, "P")
 
         changes = writeToDisk(dtree, outdir, self, odtree)
-        if changes: # Need to update openTypeHeadCreated if there have been any changes to the font
+        if changes and self.outparams["updateTimestamps"]: # Need to update openTypeHeadCreated if there have been any changes to the font
             if "fontinfo" in self.__dict__:
                 self.fontinfo.setval("openTypeHeadCreated", "string",
                                      datetime.datetime.now().strftime("%Y/%m/%d %H:%M:%S"))


### PR DESCRIPTION
Fixes #94.

I've only tested my fix locally with `psfnormalize` though. May I expect that the preexisting tests will at least make sure that my code doesn't introduce any regressions in functionality?